### PR TITLE
Include titleCase npm module to format legend labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "redux-router": "^1.0.0-beta3",
     "redux-thunk": "^1.0.0",
     "request": "^2.65.0",
+    "title-case": "^2.1.0",
     "victory-axis": "^1.5.1",
     "victory-bar": "^2.4.4",
     "victory-chart": "^2.0.1",

--- a/src/components/controls/legend-item.js
+++ b/src/components/controls/legend-item.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Radium from "radium";
+import titleCase from "title-case";
 // import d3 from "d3";
 // import _ from "lodash";
 // import Flex from "./framework/flex";
@@ -43,8 +44,8 @@ class LegendItem extends React.Component {
     };
   }
   createLabelText(d) {
-    // Richard - is this regex supposed to transform to caps and remove camel?
-    let label = d.toString().replace(/([a-z])([A-Z])/g, "$1 $2").replace(/,/g, ", ");
+    // We assume that label text arrives either Properly Formatted or as snake_case or as CamelCase
+    let label = titleCase(d.toString());
     if (this.props.dFreq) {
       label += "\u00D7";
     }


### PR DESCRIPTION
I don't know if this is too much overhead (compared to just doing regex), but having a single regex function to correct CamelCase and snake_case was looking gnarly.